### PR TITLE
Inserted a new role for tomcat 8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Ansible/roles/osct.tomcat-8"]
+	path = Ansible/roles/osct.tomcat-8
+	url = git@github.com:osct/tomcat-8.git


### PR DESCRIPTION
The role is managed in a external repository at

https://github.com/osct/tomcat-8

and it is available in ansible galaxy at

https://galaxy.ansible.com/osct/tomcat-8/